### PR TITLE
fixed update_counts in context.search

### DIFF
--- a/pyesgf/search/context.py
+++ b/pyesgf/search/context.py
@@ -123,7 +123,7 @@ class SearchContext(object):
         else:
             sc = self
 
-        self.__update_counts(ignore_facet_check=ignore_facet_check)
+        sc.__update_counts(ignore_facet_check=ignore_facet_check)
 
         return ResultSet(sc, batch_size=batch_size)
 


### PR DESCRIPTION
`update_counts` (with the `ignore_facet_check` parameter) is now run on the context given to the `ResultSet`.

Before when running `search` with `constraints` an additional `update_counts` was run and without the `ignore_facet_check` parameter.