### PR TITLE
allow to specify local cafile while using ats.py

### DIFF
--- a/pyesgf/security/ats.py
+++ b/pyesgf/security/ats.py
@@ -53,7 +53,7 @@ class AttributeService(object):
             openid=openid,
             attributes=attributes)
 
-    def send_request(self, openid, attributes):
+    def send_request(self, openid, attributes,cafile=None):
         post_body = self.build_request(openid, attributes)
         req = Request(self.url, post_body.encode('ascii'))
 
@@ -65,7 +65,7 @@ class AttributeService(object):
         req.add_header('Content-Length', str(len(data)))
         log.debug(req.headers)
         log.debug(data)
-        resp = urlopen(req)
+        resp = urlopen(req,cafile=cafile)
 
         return AttributeServiceResponse(resp)
 


### PR DESCRIPTION
I've tested this locally, and it should be fine to merge. This allows attribute service queries on machines with local CA-signed certificates, such as nodes in a test federation. 