### PR TITLE
added bootstrap option to examples

### DIFF
--- a/notebooks/examples/logon.ipynb
+++ b/notebooks/examples/logon.ipynb
@@ -11,6 +11,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**NOTE**: For the logon module you need to install the latest `myproxyclient` from pypi:\n",
+    "```\n",
+    "$ conda create -c conda-forge -n esgf-pyclient python=3.6 pip esgf-pyclient\n",
+    "$ conda activate esgf-pyclient\n",
+    "(esgf-pyclient) pip install myproxyclient\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Obtain MyProxy credentials to allow downloading files or using secured OpenDAP:"
    ]
   },
@@ -27,13 +39,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**NOTE**: When you run it for the first time you need to set `bootstrap=True`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "OPENID = 'https://esgf-data.dkrz.de/esgf-idp/openid/USERNAME'\n",
-    "lm.logon_with_openid(openid=OPENID, password=None)\n",
+    "lm.logon_with_openid(openid=OPENID, password=None, bootstrap=True)\n",
     "lm.is_logged_on()"
    ]
   },
@@ -41,14 +60,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**NOTE**: you may be prompted for your username if not available via your OpenID."
+    "**NOTE**: you may be prompted for your username if not available via your OpenID.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Obtain MyProxy credentials from your username, password and the MyProxy host:"
+    "Obtain MyProxy credentials from the MyProxy host in *interactive* mode asking you for *username* and *password*:"
    ]
   },
   {
@@ -58,7 +77,7 @@
    "outputs": [],
    "source": [
     "myproxy_host = 'esgf-data.dkrz.de'\n",
-    "lm.logon(username=None, password=None, hostname=myproxy_host)\n",
+    "lm.logon(hostname=myproxy_host, interactive=True, bootstrap=True)\n",
     "lm.is_logged_on()"
    ]
   },
@@ -66,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: See the ``pyesgf.logon`` module documentation for details of how to use myproxy username instead of OpenID."
+    "**NOTE**: See the ``pyesgf.logon`` module documentation for details of how to use myproxy username instead of OpenID."
    ]
   }
  ],

--- a/pyesgf/logon.py
+++ b/pyesgf/logon.py
@@ -14,7 +14,7 @@ it with logon details::
   >>> lm = LogonManager()
   >>> lm.is_logged_on()
   False
-  >>> lm.logon(username, password, myproxy_hostname)
+  >>> lm.logon(username, password, myproxy_hostname, bootstrap=True)
   >>> lm.is_logged_on()
   True
 
@@ -22,13 +22,15 @@ Logon parameters that aren't specified will be prompted for at the terminal
 by default.  The :class:`LogonManager` object also writes a ``.httprc`` file
 configuring OPeNDAP access through the NetCDF API.
 
+The option ``bootstrap=True`` is needed on the first run.
+
 You can use your OpenID to logon instead.  The logon details will be deduced
 from the OpenID where possible::
 
   >>> lm.logoff()
   >>> lm.is_logged_on()
   False
-  >>> lm.logon_with_openid(openid, password)
+  >>> lm.logon_with_openid(openid, password, bootstrap=True)
   >>> lm.is_logged_on()
   True
 


### PR DESCRIPTION
This PR fixes #47. It updates the examples for `logon` with the `bootstrap` option.