### PR TITLE
added username to logon_with_openid to script CEDA access more easily

### DIFF
--- a/pyesgf/logon.py
+++ b/pyesgf/logon.py
@@ -130,7 +130,7 @@ class LogonManager(object):
     def is_logged_on(self):
         return self.state == self.STATE_LOGGED_ON
 
-    def logon_with_openid(self, openid, password=None,
+    def logon_with_openid(self, openid, password=None, username=None,
                           bootstrap=False, update_trustroots=True,
                           interactive=True):
         """
@@ -143,7 +143,11 @@ class LogonManager(object):
         :param openid: OpenID to login with See :meth:`logon` for parameters
             ``interactive``, ``bootstrap`` and ``update_trustroots``.
         """
-        username, myproxy = self._get_logon_details(openid)
+        usern, myproxy = self._get_logon_details(openid)
+
+        if username == None:
+            username = usern
+            
         return self.logon(username, password, myproxy,
                           bootstrap=bootstrap,
                           update_trustroots=update_trustroots,


### PR DESCRIPTION
Hi,
Thank you so much for this package. I ran quite sometimes into a minor issue with the logon function when CEDA actually required a username but self._get_logon_details(openid) would not provide them.
I suggest a very small change to allow for explicit username provision to the logon_with_openid function. If left empty, everything will work as before. If provided, the username is propagated to the logon function. This fix solves the issue for me.
All the best.
Conrad