### PR TITLE
requests_cache API update

### DIFF
--- a/pyesgf/search/connection.py
+++ b/pyesgf/search/connection.py
@@ -95,7 +95,7 @@ class SearchConnection(object):
 
     def open(self):
         if (isinstance(self._passed_session, requests.Session) or isinstance(
-                self._passed_session, requests_cache.core.CachedSession)):
+                self._passed_session, requests_cache.CachedSession)):
             self.session = self._passed_session
         else:
             self.session = create_single_session(
@@ -115,7 +115,7 @@ class SearchConnection(object):
     def close(self):
         # Close the session
         if not (isinstance(self._passed_session, requests.Session) or isinstance(
-                self._passed_session, requests_cache.core.CachedSession)):
+                self._passed_session, requests_cache.CachedSession)):
             self.session.close()
         self._isopen = False
         return
@@ -361,7 +361,7 @@ def create_single_session(cache=None, expire_after=datetime.timedelta(hours=1),
     """
     if cache is not None:
         try:
-            session = (requests_cache.core
+            session = (requests_cache
                        .CachedSession(cache,
                                       expire_after=expire_after))
         except DatabaseError:
@@ -370,7 +370,7 @@ def create_single_session(cache=None, expire_after=datetime.timedelta(hours=1),
                 os.remove(cache)
             except Exception:
                 pass
-            session = (requests_cache.core
+            session = (requests_cache
                        .CachedSession(cache, expire_after=expire_after))
     else:
         session = requests.Session()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -68,7 +68,7 @@ class TestConnection(TestCase):
     def test_passed_cached_session(self):
         import requests_cache
         td = datetime.timedelta(hours=1)
-        session = requests_cache.core.CachedSession(self.cache,
+        session = requests_cache.CachedSession(self.cache,
                                                     expire_after=td)
         conn = SearchConnection(self.test_service, session=session)
         context = conn.new_context(project='cmip5')
@@ -77,7 +77,7 @@ class TestConnection(TestCase):
     def test_connection_instance(self):
         import requests_cache
         td = datetime.timedelta(hours=1)
-        session = requests_cache.core.CachedSession(self.cache,
+        session = requests_cache.CachedSession(self.cache,
                                                     expire_after=td)
         with SearchConnection(self.test_service, session=session) as conn:
             context = conn.new_context(project='cmip5')


### PR DESCRIPTION
Hello,
i ran into problems with the latest version of `requests_cache==0.6.0`. The core module is deprecated, so i removed the explicit `requests_cache.core` with `requests_cache` notation. It is also downwards compatible with earlier version.