### PR TITLE
Improvements to tests

### DIFF
--- a/tests/test_ats.py
+++ b/tests/test_ats.py
@@ -17,7 +17,7 @@ TEST_USER_DETAILS = os.environ.get('LLNL_NAME', '').split()
 
 class TestATS(TestCase):
 
-    @pytest.mark.skip(reason="needs test openid")
+    @pytest.mark.skipif(not TEST_OPENID, reason="needs test openid")
     def test_ceda_ats(self):
         service = AttributeService(ESGF_ATS_URL, 'esgf-pyclient')
         fn, ln = TEST_USER_DETAILS
@@ -39,7 +39,7 @@ class TestATS(TestCase):
         assert resp.get_status() == ('urn:oasis:names:tc:SAML:2.0:'
                                      'status:UnknownPrincipal')
 
-    @pytest.mark.skip(reason="needs test openid")
+    @pytest.mark.skipif(not TEST_OPENID, reason="needs test openid")
     def test_multi_attribute(self):
         service = AttributeService(ESGF_ATS_URL, 'esgf-pyclient')
         CMIP5_RESEARCH = 'CMIP5 Research'

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -41,7 +41,7 @@ class TestConnection(TestCase):
         #        replication configuration
         #        on the test server
         assert 'esgf-index1.ceda.ac.uk' in shards
-        # in esg-search in esgf-index1.ceda.ac.uk, there are a bunch 
+        # in esg-search in esgf-index1.ceda.ac.uk, there are a bunch
         # of replicas hosted on esgf-index2
         assert len(shards['esgf-index2.ceda.ac.uk']) > 1
 
@@ -69,7 +69,7 @@ class TestConnection(TestCase):
         import requests_cache
         td = datetime.timedelta(hours=1)
         session = requests_cache.CachedSession(self.cache,
-                                                    expire_after=td)
+                                               expire_after=td)
         conn = SearchConnection(self.test_service, session=session)
         context = conn.new_context(project='cmip5')
         assert context.facet_constraints['project'] == 'cmip5'
@@ -78,7 +78,7 @@ class TestConnection(TestCase):
         import requests_cache
         td = datetime.timedelta(hours=1)
         session = requests_cache.CachedSession(self.cache,
-                                                    expire_after=td)
+                                               expire_after=td)
         with SearchConnection(self.test_service, session=session) as conn:
             context = conn.new_context(project='cmip5')
         assert context.facet_constraints['project'] == 'cmip5'

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -41,9 +41,9 @@ class TestConnection(TestCase):
         #        replication configuration
         #        on the test server
         assert 'esgf-index1.ceda.ac.uk' in shards
-        # IPSL now replicates all non-local shards.
-        # Just check it has a few shards
-        assert len(shards['esgf-index1.ceda.ac.uk']) > 1
+        # in esg-search in esgf-index1.ceda.ac.uk, there are a bunch 
+        # of replicas hosted on esgf-index2
+        assert len(shards['esgf-index2.ceda.ac.uk']) > 1
 
     def test_url_fixing(self):
         # Switch off warnings for this case because we are testing that issue

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -96,14 +96,13 @@ class TestContext(TestCase):
         self.assertTrue(list(counts['model'].keys()) == ['IPSL-CM5A-LR'])
         self.assertTrue(list(counts['project'].keys()) == ['CMIP5'])
 
-    
     def _test_distrib(self, constraints=None, test_service=None,
                       cache=None):
-        if constraints == None:
-            constraints={}
-        if test_service == None:
+        if constraints is None:
+            constraints = {}
+        if test_service is None:
             test_service = self.test_service
-        
+
         conn1 = SearchConnection(test_service, distrib=False, cache=cache)
         context1 = conn1.new_context(**constraints)
         count1 = context1.hit_count
@@ -113,7 +112,6 @@ class TestContext(TestCase):
         count2 = context2.hit_count
 
         assert count1 < count2
-
 
     _distrib_constraints_few_facets = {'project': 'CMIP5',
                                        'facets': _test_few_facets}
@@ -125,8 +123,8 @@ class TestContext(TestCase):
 
     @pytest.mark.slow
     @pytest.mark.xfail
-    # Expected failure: with facets=* the distrib=true appears to be 
-    # ignored.  This is observed both on the CEDA and also DKRZ index nodes 
+    # Expected failure: with facets=* the distrib=true appears to be
+    # ignored.  This is observed both on the CEDA and also DKRZ index nodes
     # (the only nodes investigated).
     def test_distrib_with_all_facets(self):
         self._test_distrib(constraints=self._distrib_constraints_all_facets)
@@ -142,7 +140,6 @@ class TestContext(TestCase):
     def test_distrib_with_cache_with_all_facets(self):
         self._test_distrib(constraints=self._distrib_constraints_all_facets,
                            cache=self.cache)
-
 
     def test_constrain(self):
         conn = SearchConnection(self.test_service, cache=self.cache)

--- a/tests/test_logon.py
+++ b/tests/test_logon.py
@@ -20,7 +20,7 @@ except (ImportError, SyntaxError):
 TEST_USER = os.environ.get('USERNAME')
 TEST_PASSWORD = os.environ.get('PASSWORD')
 TEST_OPENID = os.environ.get('OPENID')
-TEST_MYPROXY = 'slcs1.ceda.ac.uk'
+TEST_MYPROXY = 'slcs.ceda.ac.uk'
 
 
 TEST_DATA_DIR = op.join(op.dirname(__file__), 'data')

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -243,7 +243,7 @@ class TestResults(TestCase):
 
     def _test_batch_size_has_no_impact_on_results(self, facets=None):
         conn = SearchConnection(self.test_service, distrib=True)
-        
+
         constraints = {
             'mip_era': 'CMIP6',
             'institution_id': 'CCCma',
@@ -252,7 +252,7 @@ class TestResults(TestCase):
             'variable_id': 'ua',
             'facets': facets}
         ctx = conn.new_context(**constraints)
-            
+
         results = ctx.search(batch_size=50)
         ids_batch_size_50 = sorted(results, key=lambda x: x.dataset_id)
 


### PR DESCRIPTION
This fixes some tests, and also in some cases where failures arise when using facets=*, tests are split into pairs of tests: an xfail with facets=* and a passing test where a few facets are specified. (With facets=* not all expected results are included.)