### PR TITLE
fix #74, #75 and update tests (see description)

### DIFF
--- a/pyesgf/search/connection.py
+++ b/pyesgf/search/connection.py
@@ -50,7 +50,7 @@ class SearchConnection(object):
         Usually this is http://<hostname>/esg-search
     :ivar distrib: Boolean stating whether searches through this connection are
         distributed.  i.e. whether the Search service distributes the query to
-        other search peers.  See also the documentation for the ``'facets'``
+        other search peers.  See also the documentation for the ``facets``
         argument to ``pyesgf.search.context.SearchContext`` in relation to
         distributed searches.
     :ivar cache: Path to `sqlite` cache file. Cache expires every hours.

--- a/pyesgf/search/connection.py
+++ b/pyesgf/search/connection.py
@@ -49,8 +49,10 @@ class SearchConnection(object):
         of the ESGF search service excluding the final endpoint name.
         Usually this is http://<hostname>/esg-search
     :ivar distrib: Boolean stating whether searches through this connection are
-        distributed.  I.e. whether the Search service distributes the query to
-        other search peers.
+        distributed.  i.e. whether the Search service distributes the query to
+        other search peers.  See also the documentation for the ``'facets'``
+        argument to ``pyesgf.search.context.SearchContext`` in relation to
+        distributed searches.
     :ivar cache: Path to `sqlite` cache file. Cache expires every hours.
     :ivar timeout: Time (in seconds) before query returns an error.
                    Default: 120s.

--- a/pyesgf/search/context.py
+++ b/pyesgf/search/context.py
@@ -22,8 +22,7 @@ from .exceptions import EsgfSearchException
 
 
 class SearchContext(object):
-    """
-    Instances of this class represent the state of a current search.
+    """Instances of this class represent the state of a current search.
     It exposes what facets are available to select and the facet counts
     if they are available.
 
@@ -37,6 +36,15 @@ class SearchContext(object):
 
     :ivar constraints: A dictionary of facet constraints currently in effect.
         ``constraint[facet_name] = [value, value, ...]``
+
+    :ivar facets: A string containing a comma-separated list of facets to be
+        returned (for example ``'source_id,ensemble_id'``). If set, this will
+        be used to select which facet counts to include, as returned in the
+        ``facet_counts`` dictionary.  Defaults to including all available
+        facets, but with distributed searches (where the SearchConnection
+        instance was created with ``distrib=True``), some results may be
+        missing for server-side reasons when requesting all facets, so a
+        warning message will be issued. This contains further details.
     :property facet_counts: A dictionary of available hits with each
         facet value for the search as currently constrained.
         This property returns a dictionary of dictionaries where
@@ -228,7 +236,7 @@ successfully perform a distributed search when this option is used, so some
 results may be missing.  For full results, it is recommended to pass a list of
 facets of interest when instantiating a context object.  For example,
 
-      ctx = conn.new_context(facets=['project', 'experiment_id'])
+      ctx = conn.new_context(facets='project,experiment_id')
 
 Only the facets that you specify will be present in the facets_counts dictionary.
 

--- a/pyesgf/search/results.py
+++ b/pyesgf/search/results.py
@@ -39,7 +39,7 @@ class ResultSet(Sequence):
         self.__batch_cache = {}
         self.__len_cache = None
         if eager:
-            self.__batch_cache[0] = self.__get_batch(0)
+            self.__get_batch(0)
 
     def __getitem__(self, index):
         batch_i = index // self.batch_size

--- a/pyesgf/search/results.py
+++ b/pyesgf/search/results.py
@@ -99,7 +99,7 @@ class BaseResult(object):
 
     Subclasses represent different search types such as File and Dataset.
 
-    :ivar json: The oroginial json representation of the result.
+    :ivar json: The original json representation of the result.
     :ivar context: The SearchContext which generated this result.
     :property urls: a dictionary of the form
                     ``{service: [(url, mime_type), ...], ...}``

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -41,7 +41,7 @@ class TestConnection(TestCase):
         #        replication configuration
         #        on the test server
         assert 'esgf-index1.ceda.ac.uk' in shards
-        # in esg-search in esgf-index1.ceda.ac.uk, there are a bunch 
+        # in esg-search in esgf-index1.ceda.ac.uk, there are a bunch
         # of replicas hosted on esgf-index2
         assert len(shards['esgf-index2.ceda.ac.uk']) > 1
 
@@ -69,7 +69,7 @@ class TestConnection(TestCase):
         import requests_cache
         td = datetime.timedelta(hours=1)
         session = requests_cache.CachedSession(self.cache,
-                                                    expire_after=td)
+                                               expire_after=td)
         conn = SearchConnection(self.test_service, session=session)
         context = conn.new_context(project='cmip5')
         assert context.facet_constraints['project'] == 'cmip5'
@@ -78,7 +78,7 @@ class TestConnection(TestCase):
         import requests_cache
         td = datetime.timedelta(hours=1)
         session = requests_cache.CachedSession(self.cache,
-                                                    expire_after=td)
+                                               expire_after=td)
         with SearchConnection(self.test_service, session=session) as conn:
             context = conn.new_context(project='cmip5')
         assert context.facet_constraints['project'] == 'cmip5'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -158,6 +158,7 @@ class TestContext(TestCase):
         self._test_distrib(constraints=self._distrib_constraints_all_facets,
                            cache=self.cache)
 
+    @pytest.mark.xfail("may sometimes fail if server returns incomplete set of results")
     def test_constrain(self):
         conn = SearchConnection(self.test_service, cache=self.cache)
 
@@ -186,6 +187,7 @@ class TestContext(TestCase):
         context2 = context.constrain(experiment='historical')
         self.assertTrue('experiment' in context2.facet_constraints)
 
+    @pytest.mark.xfail("may sometimes fail if server returns incomplete set of results")
     def test_negative_facet(self):
         conn = SearchConnection(self.test_service, cache=self.cache)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -13,14 +13,15 @@ import os
 _all_facets_explanation = ('tests with facets=* may fail for server-side reasons, '
                            'so these are marked XFAIL but may sometimes pass')
 
+
 class TestContext(TestCase):
 
     _test_few_facets = 'project,model,index_node,data_node'
 
     def setUp(self):
         self.test_service = 'http://esgf-data.dkrz.de/esg-search'
-        #self.test_service = 'http://esgf-index1.ceda.ac.uk/esg-search'
-        #self.test_service = 'http://esgf-node.llnl.gov/esg-search'
+        # self.test_service = 'http://esgf-index1.ceda.ac.uk/esg-search'
+        # self.test_service = 'http://esgf-node.llnl.gov/esg-search'
         self.cache = os.path.join(os.path.dirname(__file__), 'url_cache')
 
     def test_context_freetext(self):
@@ -125,7 +126,7 @@ class TestContext(TestCase):
         # server-side reasons, so we use a weaker test here.
         #
 
-        #assert count1 < count2
+        # assert count1 < count2
         assert count1 <= count2
 
     _distrib_constraints_few_facets = {'project': 'CMIP5',

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -158,7 +158,7 @@ class TestContext(TestCase):
         self._test_distrib(constraints=self._distrib_constraints_all_facets,
                            cache=self.cache)
 
-    @pytest.mark.xfail("may sometimes fail if server returns incomplete set of results")
+    @pytest.mark.xfail(reason="may sometimes fail if server returns incomplete set of results")
     def test_constrain(self):
         conn = SearchConnection(self.test_service, cache=self.cache)
 
@@ -187,7 +187,7 @@ class TestContext(TestCase):
         context2 = context.constrain(experiment='historical')
         self.assertTrue('experiment' in context2.facet_constraints)
 
-    @pytest.mark.xfail("may sometimes fail if server returns incomplete set of results")
+    @pytest.mark.xfail(reason="may sometimes fail if server returns incomplete set of results")
     def test_negative_facet(self):
         conn = SearchConnection(self.test_service, cache=self.cache)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -73,7 +73,7 @@ class TestContext(TestCase):
 
         self.assertTrue(hits2 > hits1)
 
-    @pytest.mark.xfail("results may sometimes be missing - may or may not pass")
+    @pytest.mark.xfail(reason="results may sometimes be missing - may or may not pass")
     def test_context_facet_options(self):
         conn = SearchConnection(self.test_service, cache=self.cache)
         context = conn.new_context(project='CMIP5', model='IPSL-CM5A-LR',

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -73,6 +73,7 @@ class TestContext(TestCase):
 
         self.assertTrue(hits2 > hits1)
 
+    @pytest.mark.xfail("results may sometimes be missing - may or may not pass")
     def test_context_facet_options(self):
         conn = SearchConnection(self.test_service, cache=self.cache)
         context = conn.new_context(project='CMIP5', model='IPSL-CM5A-LR',

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -96,14 +96,13 @@ class TestContext(TestCase):
         self.assertTrue(list(counts['model'].keys()) == ['IPSL-CM5A-LR'])
         self.assertTrue(list(counts['project'].keys()) == ['CMIP5'])
 
-    
     def _test_distrib(self, constraints=None, test_service=None,
                       cache=None):
-        if constraints == None:
-            constraints={}
-        if test_service == None:
+        if constraints is None:
+            constraints = {}
+        if test_service is None:
             test_service = self.test_service
-        
+
         conn1 = SearchConnection(test_service, distrib=False, cache=cache)
         context1 = conn1.new_context(**constraints)
         count1 = context1.hit_count
@@ -113,7 +112,6 @@ class TestContext(TestCase):
         count2 = context2.hit_count
 
         assert count1 < count2
-
 
     _distrib_constraints_few_facets = {'project': 'CMIP5',
                                        'facets': _test_few_facets}
@@ -125,8 +123,8 @@ class TestContext(TestCase):
 
     @pytest.mark.slow
     @pytest.mark.xfail
-    # Expected failure: with facets=* the distrib=true appears to be 
-    # ignored.  This is observed both on the CEDA and also DKRZ index nodes 
+    # Expected failure: with facets=* the distrib=true appears to be
+    # ignored.  This is observed both on the CEDA and also DKRZ index nodes
     # (the only nodes investigated).
     def test_distrib_with_all_facets(self):
         self._test_distrib(constraints=self._distrib_constraints_all_facets)
@@ -142,7 +140,6 @@ class TestContext(TestCase):
     def test_distrib_with_cache_with_all_facets(self):
         self._test_distrib(constraints=self._distrib_constraints_all_facets,
                            cache=self.cache)
-
 
     def test_constrain(self):
         conn = SearchConnection(self.test_service, cache=self.cache)

--- a/tests/test_logon.py
+++ b/tests/test_logon.py
@@ -17,10 +17,11 @@ try:
 except (ImportError, SyntaxError):
     _has_myproxy = False
 
+
 TEST_USER = os.environ.get('USERNAME')
 TEST_PASSWORD = os.environ.get('PASSWORD')
 TEST_OPENID = os.environ.get('OPENID')
-TEST_MYPROXY = 'slcs.ceda.ac.uk'
+TEST_MYPROXY = os.environ.get('MYPROXY')
 
 
 TEST_DATA_DIR = op.join(op.dirname(__file__), 'data')

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -243,7 +243,7 @@ class TestResults(TestCase):
 
     def _test_batch_size_has_no_impact_on_results(self, facets=None):
         conn = SearchConnection(self.test_service, distrib=True)
-        
+
         constraints = {
             'mip_era': 'CMIP6',
             'institution_id': 'CCCma',
@@ -252,7 +252,7 @@ class TestResults(TestCase):
             'variable_id': 'ua',
             'facets': facets}
         ctx = conn.new_context(**constraints)
-            
+
         results = ctx.search(batch_size=50)
         ids_batch_size_50 = sorted(results, key=lambda x: x.dataset_id)
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -29,6 +29,16 @@ class TestResults(TestCase):
         assert re.match(r'cmip5\.output1\..+\|esgf-data1.ceda.ac.uk',
                         r1.dataset_id)
 
+    def test_result1_ignore_facet_check(self):
+        conn = SearchConnection(self.test_service, distrib=False)
+
+        ctx = conn.new_context(project='CMIP5')
+        results = ctx.search(ignore_facet_check=True)
+
+        r1 = results[0]
+        assert re.match(r'cmip5\.output1\..+\|esgf-data1.ceda.ac.uk',
+                        r1.dataset_id)
+
     def test_file_context(self):
         conn = SearchConnection(self.test_service, distrib=False)
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -281,4 +281,3 @@ class TestResults(TestCase):
     def test_batch_size_has_no_impact_on_results_with_few_facets(self):
         self._test_batch_size_has_no_impact_on_results(
             facets=self._test_facets)
-

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -242,7 +242,12 @@ class TestResults(TestCase):
             print((j.download_url, j.checksum, j.checksum_type, j.size))
 
     def _test_batch_size_has_no_impact_on_results(self, facets=None):
-        conn = SearchConnection(self.test_service, distrib=True)
+
+        # should work in principle with distrib=True, but use distrib=False
+        # because sometimes returned results misses results from some other indexes
+        # and we don't want this to cause a failure
+
+        conn = SearchConnection(self.test_service, distrib=False)
 
         constraints = {
             'mip_era': 'CMIP6',

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -13,7 +13,7 @@ from pyesgf.search.connection import SearchConnection
 
 class TestResults(TestCase):
 
-    _test_few_facets = 'project,model,index_node,data_node'
+    _test_facets = 'project,model,index_node,data_node'
 
     def setUp(self):
         self.test_service = 'http://esgf-index1.ceda.ac.uk/esg-search'
@@ -278,11 +278,7 @@ class TestResults(TestCase):
         assert len(ids_batch_size_50) == len(ids_batch_size_100)
 
     @pytest.mark.slow
-    def test_test_batch_size_has_no_impact_on_results_with_few_facets(self):
+    def test_batch_size_has_no_impact_on_results_with_few_facets(self):
         self._test_batch_size_has_no_impact_on_results(
-            facets=self._test_few_facets)
+            facets=self._test_facets)
 
-    @pytest.mark.slow
-    @pytest.mark.xfail
-    def test_test_batch_size_has_no_impact_on_results_with_all_facets(self):
-        self._test_batch_size_has_no_impact_on_results()


### PR DESCRIPTION
Sorry to put more than one change into a single pull request, but the purpose was to fix some tests and merge conflicts etc and get all this ironed out before merging to master.

The changes include fixes to #74 and #75 from bouweandela and myself, but also there are changes to the tests, and these include marking a number of tests as expected failure where they depend on servers returning a certain number of results (or in particular, comparing the number of results from two different queries) -- we know that sometimes some of the results are missing (e.g. if a server does not respond in time on a distributed search), and we don't want the tests to break merely for that reason. Some tests marked as "xfail" for this reason may in fact pass (reported as "xpass" by pytest).