### PR TITLE
Fix `test_connection`: replace solr with solr1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - fix_test_connection
   pull_request:
     branches:
     - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - fix_test_connection
   pull_request:
     branches:
     - master

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -40,11 +40,11 @@ class TestConnection(TestCase):
         # !NOTE: the exact shard list will change depending on the shard
         #        replication configuration
         #        on the test server
-        assert 'esgf-solr.ceda.ac.uk' in shards
+        assert 'esgf-solr1.ceda.ac.uk' in shards
         # in esg-search in esgf.ceda.ac.uk, there are a bunch
         # of replicas hosted on esgf-index2
         print("Shards:", shards)
-        assert len(shards['esgf-solr.ceda.ac.uk']) > 1
+        assert len(shards['esgf-solr1.ceda.ac.uk']) > 1
 
     def test_url_fixing(self):
         # Switch off warnings for this case because we are testing that issue


### PR DESCRIPTION
The nightly tests have been dying for a whole now, see [latest fail](https://github.com/ESGF/esgf-pyclient/actions/runs/8716884907/job/23911106737) - this fixes that :beer: 