### PR TITLE
skip all ATS tests since OpenID is getting retired

### DIFF
--- a/tests/test_ats.py
+++ b/tests/test_ats.py
@@ -17,7 +17,7 @@ TEST_USER_DETAILS = os.environ.get('DKRZ_NAME', '').split()
 
 class TestATS(TestCase):
 
-    @pytest.mark.skipif(not TEST_OPENID, reason="needs test openid")
+    @pytest.mark.skip(reason="OpenID is getting retired")
     def test_ceda_ats(self):
         service = AttributeService(ESGF_ATS_URL, 'esgf-pyclient')
         fn, ln = TEST_USER_DETAILS
@@ -30,7 +30,7 @@ class TestATS(TestCase):
         assert attrs['urn:esg:first:name'] == fn
         assert attrs['urn:esg:last:name'] == ln
 
-    @pytest.mark.skipif(not TEST_OPENID, reason="needs test openid")
+    @pytest.mark.skip(reason="OpenID is getting retired")
     def test_unknown_principal(self):
         service = AttributeService(ESGF_ATS_URL, 'esgf-pyclient')
         openid = 'https://example.com/unknown'
@@ -40,7 +40,7 @@ class TestATS(TestCase):
         assert resp.get_status() == ('urn:oasis:names:tc:SAML:2.0:'
                                      'status:UnknownPrincipal')
 
-    @pytest.mark.skipif(not TEST_OPENID, reason="needs test openid")
+    @pytest.mark.skip(reason="OpenID is getting retired")
     def test_multi_attribute(self):
         service = AttributeService(ESGF_ATS_URL, 'esgf-pyclient')
         CMIP5_RESEARCH = 'CMIP5 Research'

--- a/tests/test_ats.py
+++ b/tests/test_ats.py
@@ -30,6 +30,7 @@ class TestATS(TestCase):
         assert attrs['urn:esg:first:name'] == fn
         assert attrs['urn:esg:last:name'] == ln
 
+    @pytest.mark.skipif(not TEST_OPENID, reason="needs test openid")
     def test_unknown_principal(self):
         service = AttributeService(ESGF_ATS_URL, 'esgf-pyclient')
         openid = 'https://example.com/unknown'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -19,7 +19,7 @@ class TestContext(TestCase):
     _test_few_facets = 'project,model,index_node,data_node'
 
     def setUp(self):
-        # DKRZ have retired CMIP5 data 
+        # DKRZ have retired CMIP5 data
         # self.test_service = 'http://esgf-data.dkrz.de/esg-search'
         self.test_service = 'https://esgf.ceda.ac.uk/esg-search'
         # self.test_service = 'http://esgf-node.llnl.gov/esg-search'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -19,7 +19,6 @@ class TestContext(TestCase):
     _test_few_facets = 'project,model,index_node,data_node'
 
     def setUp(self):
-        # DKRZ have retired CMIP5 data
         # self.test_service = 'http://esgf-data.dkrz.de/esg-search'
         self.test_service = 'https://esgf.ceda.ac.uk/esg-search'
         # self.test_service = 'http://esgf-node.llnl.gov/esg-search'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -19,8 +19,9 @@ class TestContext(TestCase):
     _test_few_facets = 'project,model,index_node,data_node'
 
     def setUp(self):
-        self.test_service = 'http://esgf-data.dkrz.de/esg-search'
-        # self.test_service = 'https://esgf.ceda.ac.uk/esg-search'
+        # DKRZ have retired CMIP5 data 
+        # self.test_service = 'http://esgf-data.dkrz.de/esg-search'
+        self.test_service = 'https://esgf.ceda.ac.uk/esg-search'
         # self.test_service = 'http://esgf-node.llnl.gov/esg-search'
         self.cache = os.path.join(os.path.dirname(__file__), 'url_cache')
 


### PR DESCRIPTION
[CI Tests](https://github.com/ESGF/esgf-pyclient/actions/runs/9789072623/job/27028151517) started failing again because the OpenID service at DKRZ has been retired.