### PR TITLE
retire Mambaforge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: conda --version
       - run: python -V

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: esgf-pyclient
           environment-file: environment.yml


### PR DESCRIPTION
Mambaforge is getting sunsetted, and will be completely retired in 2025. Tests are failing due to issue with CEDA archive (still to hear what to do about it from JASMIN), see #107 