### PR TITLE
Fix GitHub workflow execution warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,12 @@ jobs:
       fail-fast: false
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: conda-incubator/setup-miniconda@v3
         with:
+          conda-remove-defaults: true
           activate-environment: esgf-pyclient
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
@@ -37,7 +38,7 @@ jobs:
       - run: conda --version
       - run: python -V
       - name: Install 📦
-        run: pip install -e .[develop]
+        run: pip install -e .[dev]
       - name: Inspect environment
         run: conda list
       - name: Lint with flake8 ⚙️

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@
 name: esgf-pyclient
 channels:
   - conda-forge
-  - nodefaults
 
 dependencies:
   # installation

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -252,8 +252,7 @@ class TestContext(TestCase):
 
     @pytest.mark.slow
     def test_context_project_cmip6(self):
-        test_service = 'https://esgf-node.llnl.gov/esg-search'
-        conn = SearchConnection(test_service)
+        conn = SearchConnection(self.test_service)
 
         context = conn.new_context(project='CMIP6', institution_id='AWI', distrib=False)
         self.assertTrue(context.hit_count > 100)


### PR DESCRIPTION
This PR introduces the following changes:

* Update `actions/checkout@v4` to `v5`
* Fix setup-miniconda warnings that `nodefaults` is deprecated and `conda-remove-defaults=true` should be used instead [[recent example of warnings](https://github.com/ESGF/esgf-pyclient/actions/runs/12962267640)]
* Fix the `pip install` command to use `.[dev]` (there is no `develop` extra defined in `setup.py`)

It is expected that these changes will silence some warnings that appear in the GitHub workflow execution.