### PR TITLE
Fix a deprecation warning in `logon.py`

### DIFF
--- a/pyesgf/logon.py
+++ b/pyesgf/logon.py
@@ -275,7 +275,7 @@ class LogonManager(object):
 
         sections = re.split(r'^# (?:BEGIN|END) {0}$\n'
                             .format(DAP_CONFIG_MARKER),
-                            config_str, re.M)
+                            config_str, flags=re.M)
 
         if len(sections) < 2:
             preamble, managed, postamble = sections[0], '', ''


### PR DESCRIPTION
When running the test suite, the following warning is displayed after the tests have finished running:

```
  /home/kurt/dev/pr-esgf-pyclient/pyesgf/logon.py:276:
  DeprecationWarning: 'maxsplit' is passed as positional argument
    sections = re.split(r'^# (?:BEGIN|END) {0}$\n'
```

It's obvious from context that `re.M` is intended to be a flag, so this warning is fixed by moving `re.M` to a keyword parameter.